### PR TITLE
Extraneous module.exports line breaks auth-google

### DIFF
--- a/packages/auth-google/index.js
+++ b/packages/auth-google/index.js
@@ -37,5 +37,3 @@ module.exports = ({ config, host, app }) => {
         }
     };
 };
-
-module.exports = {};


### PR DESCRIPTION
Removed last line of file to make this plugin work again